### PR TITLE
Update terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fuel Bridge Fungible Token
 
-The contract responsible for sending/receiving messages from the base layer ERC20 gateway to mint/burn representative tokens on the Fuel chain.
+The contract responsible for sending/receiving messages from the base layer gateway to mint/burn representative proxy tokens on the Fuel chain.
 
 ## Table of contents
 

--- a/bridge-fungible-token-abi/src/bridge_fungible_token_abi.sw
+++ b/bridge-fungible-token-abi/src/bridge_fungible_token_abi.sw
@@ -3,17 +3,16 @@ library bridge_fungible_token_abi;
 use std::vm::evm::evm_address::EvmAddress;
 
 abi BridgeFungibleToken {
-    /// Claim a refund for an address if one has been registered.
+    /// Claim a refund for incorrectly bridged tokens if one has been registered.
     ///
     /// # Arguments
     ///
     /// * `originator` - the address entitled to a refund
-    /// * `asset` - the L1 token to be refunded back to the originator
+    /// * `asset` - the token to be refunded back to the originator
     #[storage(read, write)]
     fn claim_refund(originator: b256, asset: b256);
 
-    /// Withdraw coins back to L1 and burn the corresponding amount of coins
-    /// on L2.
+    /// Withdraw coins back to the base layer and burn the corresponding proxy coins.
     ///
     /// # Arguments
     ///
@@ -23,24 +22,25 @@ abi BridgeFungibleToken {
     ///
     /// * When no coins were sent with call
     /// * When the wrong asset was sent with the call
+    /// * When the amount sent overflows/underflows during decimal conversion
     #[payable]
     fn withdraw_to(to: b256);
 
-    /// Get the name of this token contract
+    /// Get the name of the proxy token
     fn name() -> str[32];
 
-    /// Get the symbol of this token contract
+    /// Get the symbol of the proxy token
     fn symbol() -> str[32];
 
-    /// Get the decimals of this token contract
+    /// Get the decimals of the proxy token
     fn decimals() -> u8;
 
-    /// Get the L1 token that this contract bridges
-    fn layer1_token() -> b256;
+    /// Get the bridged token
+    fn bridged_token() -> b256;
 
-    /// Get the L1 decimals of this token contract
-    fn layer1_decimals() -> u8;
+    /// Get the bridged token decimals
+    fn bridged_token_decimals() -> u8;
 
-    /// Get the Address of the L1 erc20 gateway used by this contract
-    fn layer1_erc20_gateway() -> b256;
+    /// Get the address of the gateway that holds the bridged tokens
+    fn bridged_token_gateway() -> b256;
 }

--- a/bridge-fungible-token/Forc.toml
+++ b/bridge-fungible-token/Forc.toml
@@ -9,9 +9,9 @@ bridge_fungible_token_abi = { path = "../bridge-fungible-token-abi" }
 contract_message_receiver = { path = "../bridge-message-predicates/contract-message-receiver" }
 
 [constants]
+BRIDGED_TOKEN = { type = "b256", value = "0x00000000000000000000000000000000000000000000000000000000deadbeef" }
+BRIDGED_TOKEN_DECIMALS = { type = "u8", value = "18u8" }
+BRIDGED_TOKEN_GATEWAY = { type = "b256", value = "0x00000000000000000000000096c53cd98B7297564716a8f2E1de2C83928Af2fe" }
 DECIMALS = { type = "u8", value = "9u8" }
-LAYER_1_DECIMALS = { type = "u8", value = "18u8" }
-LAYER_1_ERC20_GATEWAY = { type = "b256", value = "0x00000000000000000000000096c53cd98B7297564716a8f2E1de2C83928Af2fe" }
-LAYER_1_TOKEN = { type = "b256", value = "0x00000000000000000000000000000000000000000000000000000000deadbeef" }
 NAME = { type = "str[32]", value = "\"________________________MY_TOKEN\"" }
 SYMBOL = { type = "str[32]", value = "\"___________________________MYTKN\"" }

--- a/bridge-fungible-token/src/data.sw
+++ b/bridge-fungible-token/src/data.sw
@@ -3,8 +3,7 @@ library data;
 use std::{address::Address, contract_id::ContractId};
 
 pub struct MessageData {
-    fuel_token: ContractId,
-    l1_asset: b256,
+    token: b256,
     from: b256,
     to: Address,
     amount: b256,

--- a/bridge-fungible-token/tests/harness.rs
+++ b/bridge-fungible-token/tests/harness.rs
@@ -11,17 +11,14 @@ use utils::environment as env;
 use fuels::tx::{Address, AssetId, Receipt};
 use fuels::{prelude::*, types::Bits256};
 
-pub const L1_TOKEN: &str = "0x00000000000000000000000000000000000000000000000000000000deadbeef";
-pub const LAYER_1_ERC20_GATEWAY: &str =
+pub const BRIDGED_TOKEN: &str =
+    "0x00000000000000000000000000000000000000000000000000000000deadbeef";
+pub const BRIDGED_TOKEN_GATEWAY: &str =
     "0x00000000000000000000000096c53cd98B7297564716a8f2E1de2C83928Af2fe";
 pub const TO: &str = "0x0000000000000000000000000000000000000000000000000000000000000777";
 pub const FROM: &str = "0x0000000000000000000000008888888888888888888888888888888888888888";
-// In the case where (LAYER_1_DECIMALS - LAYER_2_DECIMALS) > 19, some tests
-// will fail with RevertTransactionError("ArithmeticOverflow").
-// BridgeFungibleToken contracts should not be deployed in this configuration
-// as it could lead to lost L1 tokens.
-pub const LAYER_1_DECIMALS: u8 = 18u8;
-pub const LAYER_2_DECIMALS: u8 = 9u8;
+pub const BRIDGED_TOKEN_DECIMALS: u8 = 18u8;
+pub const PROXY_TOKEN_DECIMALS: u8 = 9u8;
 
 mod success {
     use super::*;
@@ -31,9 +28,9 @@ mod success {
         let mut wallet = env::setup_wallet();
 
         // generate the test config struct based on the decimals
-        let config = env::generate_test_config((LAYER_1_DECIMALS, LAYER_2_DECIMALS));
+        let config = env::generate_test_config((BRIDGED_TOKEN_DECIMALS, PROXY_TOKEN_DECIMALS));
         let (message, coin) = env::construct_msg_data(
-            L1_TOKEN,
+            BRIDGED_TOKEN,
             FROM,
             wallet.address().hash().to_vec(),
             config.test_amount,
@@ -76,7 +73,7 @@ mod success {
         // Check that wallet now has bridged coins
         assert_eq!(
             balance,
-            env::l2_equivalent_amount(config.test_amount, &config)
+            env::fuel_side_equivalent_amount(config.test_amount, &config)
         );
     }
 
@@ -84,10 +81,10 @@ mod success {
     async fn depositing_max_amount_ok() {
         let mut wallet = env::setup_wallet();
 
-        let config = env::generate_test_config((LAYER_1_DECIMALS, LAYER_2_DECIMALS));
+        let config = env::generate_test_config((BRIDGED_TOKEN_DECIMALS, PROXY_TOKEN_DECIMALS));
 
         let (message, coin) = env::construct_msg_data(
-            L1_TOKEN,
+            BRIDGED_TOKEN,
             FROM,
             wallet.address().hash().to_vec(),
             config.max_amount,
@@ -131,7 +128,7 @@ mod success {
         // Check that wallet now has bridged coins
         assert_eq!(
             balance,
-            env::l2_equivalent_amount(config.max_amount, &config)
+            env::fuel_side_equivalent_amount(config.max_amount, &config)
         );
     }
 
@@ -140,10 +137,10 @@ mod success {
         // perform a failing deposit first to register a refund & verify it, then claim and verify output message is created as expected
         let mut wallet = env::setup_wallet();
 
-        let config = env::generate_test_config((LAYER_1_DECIMALS, LAYER_2_DECIMALS));
+        let config = env::generate_test_config((BRIDGED_TOKEN_DECIMALS, PROXY_TOKEN_DECIMALS));
 
         let (message, coin) = env::construct_msg_data(
-            L1_TOKEN,
+            BRIDGED_TOKEN,
             FROM,
             wallet.address().hash().to_vec(),
             config.overflow_2,
@@ -193,7 +190,7 @@ mod success {
         );
         assert_eq!(
             refund_registered_event[0].asset,
-            Bits256::from_hex_str(&L1_TOKEN).unwrap()
+            Bits256::from_hex_str(&BRIDGED_TOKEN).unwrap()
         );
         assert_eq!(
             refund_registered_event[0].from,
@@ -206,7 +203,7 @@ mod success {
             .methods()
             .claim_refund(
                 Bits256::from_hex_str(&FROM).unwrap(),
-                Bits256::from_hex_str(&L1_TOKEN).unwrap(),
+                Bits256::from_hex_str(&BRIDGED_TOKEN).unwrap(),
             )
             .append_message_outputs(1)
             .call()
@@ -225,18 +222,18 @@ mod success {
             **message_receipt.sender().unwrap()
         );
         assert_eq!(
-            &Address::from_str(LAYER_1_ERC20_GATEWAY).unwrap(),
+            &Address::from_str(BRIDGED_TOKEN_GATEWAY).unwrap(),
             message_receipt.recipient().unwrap()
         );
         assert_eq!(message_receipt.amount().unwrap(), 0);
         assert_eq!(message_receipt.len().unwrap(), 104);
 
         // message data
-        let (selector, to, l1_token, amount) =
+        let (selector, to, token, amount) =
             env::parse_output_message_data(message_receipt.data().unwrap());
         assert_eq!(selector, env::decode_hex("0x53ef1461").to_vec());
         assert_eq!(to, Bits256::from_hex_str(&FROM).unwrap());
-        assert_eq!(l1_token, Bits256::from_hex_str(&L1_TOKEN).unwrap());
+        assert_eq!(token, Bits256::from_hex_str(&BRIDGED_TOKEN).unwrap());
         // Compare the value output in the message with the original value sent
         assert_eq!(amount, config.overflow_2);
     }
@@ -245,9 +242,9 @@ mod success {
     async fn withdraw_from_bridge() {
         // perform successful deposit first, verify it, then withdraw and verify balances
         let mut wallet = env::setup_wallet();
-        let config = env::generate_test_config((LAYER_1_DECIMALS, LAYER_2_DECIMALS));
+        let config = env::generate_test_config((BRIDGED_TOKEN_DECIMALS, PROXY_TOKEN_DECIMALS));
         let (message, coin) = env::construct_msg_data(
-            L1_TOKEN,
+            BRIDGED_TOKEN,
             FROM,
             wallet.address().hash().to_vec(),
             config.max_amount,
@@ -291,7 +288,7 @@ mod success {
         // Check that wallet now has bridged coins
         assert_eq!(
             balance,
-            env::l2_equivalent_amount(config.max_amount, &config)
+            env::fuel_side_equivalent_amount(config.max_amount, &config)
         );
 
         // Now try to withdraw
@@ -325,18 +322,18 @@ mod success {
             **message_receipt.sender().unwrap()
         );
         assert_eq!(
-            &Address::from_str(LAYER_1_ERC20_GATEWAY).unwrap(),
+            &Address::from_str(BRIDGED_TOKEN_GATEWAY).unwrap(),
             message_receipt.recipient().unwrap()
         );
         assert_eq!(message_receipt.amount().unwrap(), 0);
         assert_eq!(message_receipt.len().unwrap(), 104);
 
         // message data
-        let (selector, to, l1_token, amount) =
+        let (selector, to, token, amount) =
             env::parse_output_message_data(message_receipt.data().unwrap());
         assert_eq!(selector, env::decode_hex("0x53ef1461").to_vec());
         assert_eq!(to, Bits256(*wallet.address().hash()));
-        assert_eq!(l1_token, Bits256::from_hex_str(&L1_TOKEN).unwrap());
+        assert_eq!(token, Bits256::from_hex_str(&BRIDGED_TOKEN).unwrap());
         assert_eq!(
             amount,
             U256::from(withdrawal_amount) * &config.adjustment_factor
@@ -347,14 +344,14 @@ mod success {
     async fn decimal_conversions_are_correct() {
         // start with an eth amount
         // bridge it to Fuel
-        // bridge it back to L1
+        // bridge it back to base layer
         // compare starting value with ending value, should be identical
 
         // first make a deposit
         let mut wallet = env::setup_wallet();
-        let config = env::generate_test_config((LAYER_1_DECIMALS, LAYER_2_DECIMALS));
+        let config = env::generate_test_config((BRIDGED_TOKEN_DECIMALS, PROXY_TOKEN_DECIMALS));
         let (message, coin) = env::construct_msg_data(
-            L1_TOKEN,
+            BRIDGED_TOKEN,
             FROM,
             wallet.address().hash().to_vec(),
             config.min_amount,
@@ -396,14 +393,14 @@ mod success {
         assert_eq!(test_contract_base_asset_balance, 100);
         // Check that wallet now has bridged coins
 
-        let l2_token_amount = env::l2_equivalent_amount(config.min_amount, &config);
+        let fuel_side_token_amount = env::fuel_side_equivalent_amount(config.min_amount, &config);
 
-        assert_eq!(balance, l2_token_amount);
+        assert_eq!(balance, fuel_side_token_amount);
 
         // Now try to withdraw
         let custom_tx_params = TxParameters::new(None, Some(30_000_000), None);
         let call_params = CallParameters::new(
-            Some(l2_token_amount),
+            Some(fuel_side_token_amount),
             Some(AssetId::new(*test_contract_id.hash())),
             None,
         );
@@ -430,18 +427,18 @@ mod success {
             **message_receipt.sender().unwrap()
         );
         assert_eq!(
-            &Address::from_str(LAYER_1_ERC20_GATEWAY).unwrap(),
+            &Address::from_str(BRIDGED_TOKEN_GATEWAY).unwrap(),
             message_receipt.recipient().unwrap()
         );
         assert_eq!(message_receipt.amount().unwrap(), 0);
         assert_eq!(message_receipt.len().unwrap(), 104);
 
         // message data
-        let (selector, to, l1_token, msg_data_amount) =
+        let (selector, to, token, msg_data_amount) =
             env::parse_output_message_data(message_receipt.data().unwrap());
         assert_eq!(selector, env::decode_hex("0x53ef1461").to_vec());
         assert_eq!(to, Bits256(*wallet.address().hash()));
-        assert_eq!(l1_token, Bits256::from_hex_str(&L1_TOKEN).unwrap());
+        assert_eq!(token, Bits256::from_hex_str(&BRIDGED_TOKEN).unwrap());
 
         // now verify that the initial amount == the final amount
         assert_eq!(msg_data_amount, config.min_amount);
@@ -449,11 +446,11 @@ mod success {
 
     #[tokio::test]
     async fn depositing_amount_too_small_registers_refund() {
-        // In cases where LAYER_1_DECIMALS == LAYER_2_DECIMALS or LAYER_1_DECIMALS < LAYER_2_DECIMALS, this test will fail because it will attempt to bridge 0 coins which will always revert.
+        // In cases where BRIDGED_TOKEN_DECIMALS == PROXY_TOKEN_DECIMALS or BRIDGED_TOKEN_DECIMALS < PROXY_TOKEN_DECIMALS, this test will fail because it will attempt to bridge 0 coins which will always revert.
         let mut wallet = env::setup_wallet();
-        let config = env::generate_test_config((LAYER_1_DECIMALS, LAYER_2_DECIMALS));
+        let config = env::generate_test_config((BRIDGED_TOKEN_DECIMALS, PROXY_TOKEN_DECIMALS));
         let (message, coin) = env::construct_msg_data(
-            L1_TOKEN,
+            BRIDGED_TOKEN,
             FROM,
             wallet.address().hash().to_vec(),
             config.not_enough,
@@ -503,7 +500,7 @@ mod success {
         );
         assert_eq!(
             refund_registered_event[0].asset,
-            Bits256::from_hex_str(&L1_TOKEN).unwrap()
+            Bits256::from_hex_str(&BRIDGED_TOKEN).unwrap()
         );
         assert_eq!(
             refund_registered_event[0].from,
@@ -517,9 +514,9 @@ mod success {
     #[tokio::test]
     async fn depositing_amount_too_large_registers_refund() {
         let mut wallet = env::setup_wallet();
-        let config = env::generate_test_config((LAYER_1_DECIMALS, LAYER_2_DECIMALS));
+        let config = env::generate_test_config((BRIDGED_TOKEN_DECIMALS, PROXY_TOKEN_DECIMALS));
         let (message, coin) = env::construct_msg_data(
-            L1_TOKEN,
+            BRIDGED_TOKEN,
             FROM,
             wallet.address().hash().to_vec(),
             config.overflow_1,
@@ -571,7 +568,7 @@ mod success {
         );
         assert_eq!(
             refund_registered_event[0].asset,
-            Bits256::from_hex_str(&L1_TOKEN).unwrap()
+            Bits256::from_hex_str(&BRIDGED_TOKEN).unwrap()
         );
         assert_eq!(
             refund_registered_event[0].from,
@@ -585,10 +582,10 @@ mod success {
     #[tokio::test]
     async fn depositing_amount_too_large_registers_refund_2() {
         let mut wallet = env::setup_wallet();
-        let config = env::generate_test_config((LAYER_1_DECIMALS, LAYER_2_DECIMALS));
+        let config = env::generate_test_config((BRIDGED_TOKEN_DECIMALS, PROXY_TOKEN_DECIMALS));
 
         let (message, coin) = env::construct_msg_data(
-            L1_TOKEN,
+            BRIDGED_TOKEN,
             FROM,
             wallet.address().hash().to_vec(),
             config.overflow_2,
@@ -640,7 +637,7 @@ mod success {
         );
         assert_eq!(
             refund_registered_event[0].asset,
-            Bits256::from_hex_str(&L1_TOKEN).unwrap()
+            Bits256::from_hex_str(&BRIDGED_TOKEN).unwrap()
         );
         assert_eq!(
             refund_registered_event[0].from,
@@ -654,10 +651,10 @@ mod success {
     #[tokio::test]
     async fn depositing_amount_too_large_registers_refund_3() {
         let mut wallet = env::setup_wallet();
-        let config = env::generate_test_config((LAYER_1_DECIMALS, LAYER_2_DECIMALS));
+        let config = env::generate_test_config((BRIDGED_TOKEN_DECIMALS, PROXY_TOKEN_DECIMALS));
 
         let (message, coin) = env::construct_msg_data(
-            L1_TOKEN,
+            BRIDGED_TOKEN,
             FROM,
             wallet.address().hash().to_vec(),
             config.overflow_3,
@@ -709,7 +706,7 @@ mod success {
         );
         assert_eq!(
             refund_registered_event[0].asset,
-            Bits256::from_hex_str(&L1_TOKEN).unwrap()
+            Bits256::from_hex_str(&BRIDGED_TOKEN).unwrap()
         );
         assert_eq!(
             refund_registered_event[0].from,
@@ -747,44 +744,44 @@ mod success {
         let (contract, _id) = env::get_fungible_token_instance(wallet.clone()).await;
 
         let call_response = contract.methods().decimals().call().await.unwrap();
-        assert_eq!(call_response.value, LAYER_2_DECIMALS)
+        assert_eq!(call_response.value, PROXY_TOKEN_DECIMALS)
     }
 
     #[tokio::test]
-    async fn can_get_layer1_token() {
+    async fn can_get_bridged_token() {
         let wallet = launch_provider_and_get_wallet().await;
         // Set up the environment
         let (contract, _id) = env::get_fungible_token_instance(wallet.clone()).await;
-        let l1_token = Address::from_str(&L1_TOKEN).unwrap();
+        let bridged_token = Address::from_str(&BRIDGED_TOKEN).unwrap();
 
-        let call_response = contract.methods().layer1_token().call().await.unwrap();
-        assert_eq!(call_response.value, Bits256(*l1_token))
+        let call_response = contract.methods().bridged_token().call().await.unwrap();
+        assert_eq!(call_response.value, Bits256(*bridged_token))
     }
 
     #[tokio::test]
-    async fn can_get_layer1_decimals() {
+    async fn can_get_bridged_token_decimals() {
         let wallet = launch_provider_and_get_wallet().await;
         // Set up the environment
         let (contract, _id) = env::get_fungible_token_instance(wallet.clone()).await;
 
-        let call_response = contract.methods().layer1_decimals().call().await.unwrap();
-        assert_eq!(call_response.value, LAYER_1_DECIMALS)
+        let call_response = contract.methods().bridged_token_decimals().call().await.unwrap();
+        assert_eq!(call_response.value, BRIDGED_TOKEN_DECIMALS)
     }
 
     #[tokio::test]
-    async fn can_get_layer1_erc20_gateway() {
+    async fn can_get_bridged_token_gateway() {
         let wallet = launch_provider_and_get_wallet().await;
         // Set up the environment
         let (contract, _id) = env::get_fungible_token_instance(wallet.clone()).await;
-        let erc20_gateway = Address::from_str(&LAYER_1_ERC20_GATEWAY).unwrap();
+        let token_gateway = Address::from_str(&BRIDGED_TOKEN_GATEWAY).unwrap();
 
         let call_response = contract
             .methods()
-            .layer1_erc20_gateway()
+            .bridged_token_gateway()
             .call()
             .await
             .unwrap();
-        assert_eq!(call_response.value, Bits256(*erc20_gateway))
+        assert_eq!(call_response.value, Bits256(*token_gateway))
     }
 }
 
@@ -792,12 +789,12 @@ mod revert {
     use super::*;
 
     #[tokio::test]
-    async fn deposit_with_wrong_l1_token_registers_refund() {
+    async fn deposit_with_wrong_token_registers_refund() {
         let mut wallet = env::setup_wallet();
         let wrong_token_value: &str =
             "0x1111110000000000000000000000000000000000000000000000000000111111";
 
-        let config = env::generate_test_config((LAYER_1_DECIMALS, LAYER_2_DECIMALS));
+        let config = env::generate_test_config((BRIDGED_TOKEN_DECIMALS, PROXY_TOKEN_DECIMALS));
 
         let (message, coin) = env::construct_msg_data(
             wrong_token_value,
@@ -869,9 +866,10 @@ mod revert {
     #[should_panic(expected = "Revert(18446744073709486080)")]
     async fn verification_fails_with_wrong_sender() {
         let mut wallet = env::setup_wallet();
-        let config = env::generate_test_config((LAYER_1_DECIMALS, LAYER_2_DECIMALS));
+        let config = env::generate_test_config((BRIDGED_TOKEN_DECIMALS, PROXY_TOKEN_DECIMALS));
         let (message, coin) =
-            env::construct_msg_data(L1_TOKEN, FROM, env::decode_hex(TO), config.min_amount).await;
+            env::construct_msg_data(BRIDGED_TOKEN, FROM, env::decode_hex(TO), config.min_amount)
+                .await;
 
         let bad_sender: &str =
             "0x55555500000000000000000000000000000000000000000000000000005555555";
@@ -901,13 +899,13 @@ mod revert {
 
 #[tokio::test]
 async fn delta_decimals_too_big_registers_refund() {
-    // In cases where LAYER_1_DECIMALS - LAYER_2_DECIMALS > 19,
+    // In cases where BRIDGED_TOKEN_DECIMALS - PROXY_TOKEN_DECIMALS > 19,
     // there would be arithmetic overflow and possibly tokens lost.
     // We want to catch these cases eraly and register a refund.
     let mut wallet = env::setup_wallet();
-    let config = env::generate_test_config((LAYER_1_DECIMALS, LAYER_2_DECIMALS));
+    let config = env::generate_test_config((BRIDGED_TOKEN_DECIMALS, PROXY_TOKEN_DECIMALS));
     let (message, coin) = env::construct_msg_data(
-        L1_TOKEN,
+        BRIDGED_TOKEN,
         FROM,
         wallet.address().hash().to_vec(),
         config.test_amount,
@@ -929,7 +927,7 @@ async fn delta_decimals_too_big_registers_refund() {
     )
     .await;
 
-    if LAYER_1_DECIMALS - LAYER_2_DECIMALS > 19 {
+    if BRIDGED_TOKEN_DECIMALS - PROXY_TOKEN_DECIMALS > 19 {
         let log_decoder = test_contract.log_decoder();
         let refund_registered_event = log_decoder
             .get_logs_with_type::<RefundRegisteredEvent>(&receipts)
@@ -954,7 +952,7 @@ async fn delta_decimals_too_big_registers_refund() {
 
         assert_eq!(
             refund_registered_event[0].asset,
-            Bits256::from_hex_str(&L1_TOKEN).unwrap()
+            Bits256::from_hex_str(&BRIDGED_TOKEN).unwrap()
         );
         assert_eq!(
             refund_registered_event[0].from,

--- a/bridge-fungible-token/tests/harness.rs
+++ b/bridge-fungible-token/tests/harness.rs
@@ -764,7 +764,12 @@ mod success {
         // Set up the environment
         let (contract, _id) = env::get_fungible_token_instance(wallet.clone()).await;
 
-        let call_response = contract.methods().bridged_token_decimals().call().await.unwrap();
+        let call_response = contract
+            .methods()
+            .bridged_token_decimals()
+            .call()
+            .await
+            .unwrap();
         assert_eq!(call_response.value, BRIDGED_TOKEN_DECIMALS)
     }
 

--- a/bridge-message-predicates/contract-message-receiver/src/lib.sw
+++ b/bridge-message-predicates/contract-message-receiver/src/lib.sw
@@ -1,15 +1,6 @@
 library contract_message_receiver_abi;
 
 abi MessageReceiver {
-    /// Process a message passed to the receiver contract to facilitate a deposit of bridged tokens.
-    ///
-    /// # Arguments
-    ///
-    /// * `msg_idx` - the index of the InputMessage to process
-    ///
-    /// # Reverts
-    ///
-    /// * When the sender is not the LAYER_1_ERC20_GATEWAY
     #[storage(read, write)]
     #[payable]
     fn process_message(msg_idx: u8);

--- a/docs/deploy_docs.md
+++ b/docs/deploy_docs.md
@@ -1,6 +1,6 @@
 # Contract Deploy for Bridge
 
-Each ERC-20 token to be bridged needs to have a corresponding fungible token contract defined on the Fuel chain. These contracts handle messaging with the base layer gateway contract and are responsible for minting and burning the Fuel side token equivalents.
+Each token to be bridged needs to have a corresponding bridge fungible token contract defined on the Fuel chain. These contracts handle messaging with the base layer gateway contract and are responsible for minting and burning the Fuel side token proxies.
 
 ## Dependencies
 
@@ -11,11 +11,11 @@ Each ERC-20 token to be bridged needs to have a corresponding fungible token con
 
 ## Configure
 
-Configure the target ERC-20 token by editing the `bridge-fungible-token/Forc.toml` file:
+Configure the target base layer token by editing the `bridge-fungible-token/Forc.toml` file:
 
-- **LAYER_1_ERC20_GATEWAY**: The address of the gateway contract on the base layer
-- **LAYER_1_TOKEN**: The address of the ERC-20 token contract on the base layer
-- **LAYER_1_DECIMALS**: The decimal value of the base layer ERC-20 token contract
+- **BRIDGED_TOKEN_GATEWAY**: The address of the gateway contract on the base layer
+- **BRIDGED_TOKEN**: The address of the token contract on the base layer
+- **BRIDGED_TOKEN_DECIMALS**: The decimal value of the base layer token contract
 - **NAME**: The token name (padded to 32 characters)
 - **SYMBOL**: The token symbol (padded to 32 characters)
 

--- a/docs/design_docs.md
+++ b/docs/design_docs.md
@@ -25,7 +25,7 @@ The ETH bridge facilitates the transfer of ETH from Ethereum to be represented a
 ### ETH Bridge Withdrawal
 
 1. User starts a withdrawal by creating a transaction that outputs an `OutputMessage` with a specific amount of ETH
-1. All `OutputMessages` are committed to L1 via a merkle tree of all `OutputMessage` `messageId`s by a designated committer (either a multisig or future consensus contract)
+1. All `OutputMessages` are committed to Ethereum via a merkle tree of all `OutputMessage` `messageId`s by a designated committer (either a multisig or future consensus contract)
 1. After a finalization period, the user calls to the `FuelMessagePortal` with a merkle proof of the previously sent message which then sends the ETH to the message recipient
 
 ![ETH Withdrawal Diagram](/docs/imgs/FuelMessagingETHWithdraw.png)
@@ -36,9 +36,9 @@ The ERC-20 bridge facilitates the transfer of ERC-20 tokens from Ethereum to be 
 
 ### ERC-20 Bridge Deposit
 
-1. User starts a deposit by calling the `deposit()` function on the `L1ERC20Gateway` (after they have approved token transfer to `L1ERC20Gateway`)
-1. The `L1ERC20Gateway` transfers tokens to itself to custody while they are bridged
-1. The `L1ERC20Gateway` creates a message in the `FuelMessagePortal` to be relayed on Fuel with the `MessageToFungibleTokenPredicate` as the recipient so that anyone can spend the `InputMessage` on a user's behalf but with guarantees that the transaction is built as it’s supposed to
+1. User starts a deposit by calling the `deposit()` function on the `FuelERC20Gateway` (after they have approved token transfer to `FuelERC20Gateway`)
+1. The `FuelERC20Gateway` transfers tokens to itself to custody while they are bridged
+1. The `FuelERC20Gateway` creates a message in the `FuelMessagePortal` to be relayed on Fuel with the `MessageToFungibleTokenPredicate` as the recipient so that anyone can spend the `InputMessage` on a user's behalf but with guarantees that the transaction is built as it’s supposed to
 1. The Fuel client sees an outgoing message event emitted on the `FuelMessagePortal` and adds a corresponding `InputMessage` to the UTXO set with the designated recipient predicate
 1. A transaction is built and submitted by either the user or a relayer service that meets the requirements of the `MessageToFungibleTokenPredicate` recipient
 1. A single call is made from the transaction script to the intended target Fuel token contract specified in the messages data field. This function verifies the sender and predicate recipient of the `InputMessage`, parses the data from the `InputMessage` data field and mints the appropriate amount of tokens
@@ -49,8 +49,8 @@ The ERC-20 bridge facilitates the transfer of ERC-20 tokens from Ethereum to be 
 
 1. User starts a withdrawal by calling the `FuelMyToken` contract sending some coins to withdraw along with it
 1. The `FuelMyToken` contract looks to see what coins it was sent, burns them and then creates an `OutputMessage` via the `SMO` opcode
-1. All `OutputMessages` are committed to L1 via a merkle tree of all `OutputMessage` `messageId`s by a designated committer (either a multisig or future consensus contract)
-1. After a finalization period, the user calls to the `FuelMessagePortal` with a merkle proof of the previously sent message which then calls to the `L1ERC20Gateway` with the abi specified in the message data
-1. The `L1ERC20Gateway` verifies it’s being called by the `FuelMessagePortal` and releases the specified amount of tokens to the specified address
+1. All `OutputMessages` are committed to Ethereum via a merkle tree of all `OutputMessage` `messageId`s by a designated committer (either a multisig or future consensus contract)
+1. After a finalization period, the user calls to the `FuelMessagePortal` with a merkle proof of the previously sent message which then calls to the `FuelERC20Gateway` with the abi specified in the message data
+1. The `FuelERC20Gateway` verifies it’s being called by the `FuelMessagePortal` and releases the specified amount of tokens to the specified address
 
 ![ERC20 Withdrawal Diagram](/docs/imgs/FuelMessagingERC20Withdraw.png)


### PR DESCRIPTION
This one seems big, but is just a sweep through the code to replace terms like "layer1", "L1", "erc20" to more generic "base layer" and "bridged token" terminology. The main reason for this is to keep things reusable across different deployment contexts like a non-evm base layer or a rollup with different consensus and execution layers.