### PR TITLE
Migrate config-time consts to contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         run: rustup component add rustfmt
 
       - name: Install Fuel toolchain
-        uses: FuelLabs/action-fuel-toolchain@v0.5.0
+        uses: FuelLabs/action-fuel-toolchain@v0.6.0
         with:
           toolchain: beta-3
 

--- a/Forc.lock
+++ b/Forc.lock
@@ -19,9 +19,9 @@ dependencies = ['std']
 
 [[package]]
 name = 'core'
-source = 'path+from-root-CA3483713FB5F317'
+source = 'path+from-root-894BF76E6DA2FFD3'
 
 [[package]]
 name = 'std'
-source = 'git+https://github.com/fuellabs/sway?tag=v0.35.0#b6f19a3be7b2fb5ef88e358a926854dac10cb281'
+source = 'git+https://github.com/fuellabs/sway?tag=v0.35.3#5d2b10bd83791d2eaff04206dbd45bfdd9cf23ff'
 dependencies = ['core']

--- a/bridge-fungible-token/Forc.toml
+++ b/bridge-fungible-token/Forc.toml
@@ -9,9 +9,3 @@ bridge_fungible_token_abi = { path = "../bridge-fungible-token-abi" }
 contract_message_receiver = { path = "../bridge-message-predicates/contract-message-receiver" }
 
 [constants]
-BRIDGED_TOKEN = { type = "b256", value = "0x00000000000000000000000000000000000000000000000000000000deadbeef" }
-BRIDGED_TOKEN_DECIMALS = { type = "u8", value = "18u8" }
-BRIDGED_TOKEN_GATEWAY = { type = "b256", value = "0x00000000000000000000000096c53cd98B7297564716a8f2E1de2C83928Af2fe" }
-DECIMALS = { type = "u8", value = "9u8" }
-NAME = { type = "str[32]", value = "\"________________________MY_TOKEN\"" }
-SYMBOL = { type = "str[32]", value = "\"___________________________MYTKN\"" }

--- a/bridge-fungible-token/Forc.toml
+++ b/bridge-fungible-token/Forc.toml
@@ -3,9 +3,8 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "bridge_fungible_token.sw"
 license = "Apache-2.0"
 name = "bridge_fungible_token"
-
+S
 [dependencies]
 bridge_fungible_token_abi = { path = "../bridge-fungible-token-abi" }
 contract_message_receiver = { path = "../bridge-message-predicates/contract-message-receiver" }
 
-[constants]

--- a/bridge-fungible-token/Forc.toml
+++ b/bridge-fungible-token/Forc.toml
@@ -3,8 +3,7 @@ authors = ["Fuel Labs <contact@fuel.sh>"]
 entry = "bridge_fungible_token.sw"
 license = "Apache-2.0"
 name = "bridge_fungible_token"
-S
+
 [dependencies]
 bridge_fungible_token_abi = { path = "../bridge-fungible-token-abi" }
 contract_message_receiver = { path = "../bridge-message-predicates/contract-message-receiver" }
-

--- a/bridge-fungible-token/src/utils.sw
+++ b/bridge-fungible-token/src/utils.sw
@@ -85,7 +85,11 @@ fn shift_decimals_right(bn: U256, d: u8) -> Result<U256, BridgeFungibleTokenErro
 
 /// Adjust decimals(precision) on a withdrawal amount to match the originating token decimals
 /// or return an error if the conversion can't be achieved without overflow/underflow.
-pub fn adjust_withdrawal_decimals(val: u64, decimals: u8, bridged_token_decimals: u8) -> Result<b256, BridgeFungibleTokenError> {
+pub fn adjust_withdrawal_decimals(
+    val: u64,
+    decimals: u8,
+    bridged_token_decimals: u8,
+) -> Result<b256, BridgeFungibleTokenError> {
     let value = U256::from((0, 0, 0, val));
     let adjusted = if bridged_token_decimals > decimals {
         match shift_decimals_left(value, bridged_token_decimals - decimals) {
@@ -106,7 +110,11 @@ pub fn adjust_withdrawal_decimals(val: u64, decimals: u8, bridged_token_decimals
 
 /// Adjust decimals(precision) on a deposit amount to match this proxy tokens decimals
 /// or return an error if the conversion can't be achieved without overflow/underflow.
-pub fn adjust_deposit_decimals(val: b256, decimals: u8, bridged_token_decimals: u8) -> Result<u64, BridgeFungibleTokenError> {
+pub fn adjust_deposit_decimals(
+    val: b256,
+    decimals: u8,
+    bridged_token_decimals: u8,
+) -> Result<u64, BridgeFungibleTokenError> {
     let value = U256::from(decompose(val));
     let adjusted = if bridged_token_decimals > decimals {
         let result = shift_decimals_right(value, bridged_token_decimals - decimals);

--- a/bridge-fungible-token/src/utils.sw
+++ b/bridge-fungible-token/src/utils.sw
@@ -85,15 +85,15 @@ fn shift_decimals_right(bn: U256, d: u8) -> Result<U256, BridgeFungibleTokenErro
 
 /// Adjust decimals(precision) on a withdrawal amount to match the originating token decimals
 /// or return an error if the conversion can't be achieved without overflow/underflow.
-pub fn adjust_withdrawal_decimals(val: u64) -> Result<b256, BridgeFungibleTokenError> {
+pub fn adjust_withdrawal_decimals(val: u64, decimals: u8, bridged_token_decimals: u8) -> Result<b256, BridgeFungibleTokenError> {
     let value = U256::from((0, 0, 0, val));
-    let adjusted = if BRIDGED_TOKEN_DECIMALS > DECIMALS {
-        match shift_decimals_left(value, BRIDGED_TOKEN_DECIMALS - DECIMALS) {
+    let adjusted = if bridged_token_decimals > decimals {
+        match shift_decimals_left(value, bridged_token_decimals - decimals) {
             Result::Err(e) => return Result::Err(e),
             Result::Ok(v) => v.into(),
         }
-    } else if BRIDGED_TOKEN_DECIMALS < DECIMALS {
-        match shift_decimals_right(value, DECIMALS - BRIDGED_TOKEN_DECIMALS) {
+    } else if bridged_token_decimals < decimals {
+        match shift_decimals_right(value, decimals - bridged_token_decimals) {
             Result::Err(e) => return Result::Err(e),
             Result::Ok(v) => v.into(),
         }
@@ -106,16 +106,16 @@ pub fn adjust_withdrawal_decimals(val: u64) -> Result<b256, BridgeFungibleTokenE
 
 /// Adjust decimals(precision) on a deposit amount to match this proxy tokens decimals
 /// or return an error if the conversion can't be achieved without overflow/underflow.
-pub fn adjust_deposit_decimals(val: b256) -> Result<u64, BridgeFungibleTokenError> {
+pub fn adjust_deposit_decimals(val: b256, decimals: u8, bridged_token_decimals: u8) -> Result<u64, BridgeFungibleTokenError> {
     let value = U256::from(decompose(val));
-    let adjusted = if BRIDGED_TOKEN_DECIMALS > DECIMALS {
-        let result = shift_decimals_right(value, BRIDGED_TOKEN_DECIMALS - DECIMALS);
+    let adjusted = if bridged_token_decimals > decimals {
+        let result = shift_decimals_right(value, bridged_token_decimals - decimals);
         match result {
             Result::Err(e) => return Result::Err(e),
             Result::Ok(v) => v,
         }
-    } else if BRIDGED_TOKEN_DECIMALS < DECIMALS {
-        let result = shift_decimals_left(value, DECIMALS - BRIDGED_TOKEN_DECIMALS);
+    } else if bridged_token_decimals < decimals {
+        let result = shift_decimals_left(value, decimals - bridged_token_decimals);
         match result {
             Result::Err(e) => return Result::Err(e),
             Result::Ok(v) => v,
@@ -158,11 +158,11 @@ pub fn parse_message_data(msg_idx: u8) -> MessageData {
 }
 
 /// Encode the data to be passed out of the contract when sending a message
-pub fn encode_data(to: b256, amount: b256) -> Bytes {
+pub fn encode_data(to: b256, amount: b256, bridged_token: b256) -> Bytes {
     // capacity is 4 + 32 + 32 + 32 = 100
     let mut data = Bytes::with_capacity(100);
     let padded_to_bytes = Bytes::from(to);
-    let padded_token_bytes = Bytes::from(BRIDGED_TOKEN);
+    let padded_token_bytes = Bytes::from(bridged_token);
     let amount_bytes = Bytes::from(amount);
 
     // first, we push the selector 1 byte at a time


### PR DESCRIPTION
A follow-up will add configurable testing now that we have this.
closes #51 

I refactored to make functions in utils.sw that formerly depended on config-time consts from the manifest instead have these values passed as function params, which is much cleaner anyway.