### PR TITLE
Set up test infra for configurable tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1634,9 +1634,9 @@ dependencies = [
 
 [[package]]
 name = "fuels"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb5af8cab660ba02d2e61bc16812fdd6e93f64a5c023d510d7fb615e400704c"
+checksum = "ec9f85950c301889c074c3882ccb49fca1900f0d54a434fede12ea55d4583e12"
 dependencies = [
  "fuel-core",
  "fuel-core-client",
@@ -1651,9 +1651,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-code-gen"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e78cd0139231c728374e54cce8c2277ae1afddcee666547ce30c8a8d7f7b1f06"
+checksum = "7cfe362e48283fcb080c9f435fc1ac18aad34c3c3c91779cc99415862573faed"
 dependencies = [
  "Inflector",
  "fuel-abi-types",
@@ -1668,9 +1668,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-core"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37aa5dbcf0b1e08818ff8d9caac82e8da8e81748a83860e58979b46aa77b5d28"
+checksum = "d846794076498a56c4fdf64e62852a2e183f4a50a70492a329f54fce3830e95c"
 dependencies = [
  "fuel-tx 0.26.1",
  "fuel-types 0.26.1",
@@ -1683,9 +1683,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-macros"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b04fcfb17385f702c9aa7958e57630c3fbdf0d86e34093ced9cc3a606c192962"
+checksum = "ddb21e9d6e680e910e07aaa0b5570e54b93416d68d84dcf01c4df245168bef23"
 dependencies = [
  "Inflector",
  "fuel-abi-types",
@@ -1702,9 +1702,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-programs"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bacdabf09515dc95f3251d80ade1a876da951d988d48866c80940d594280a796"
+checksum = "6e736f3c2186876f4f7741f9c390b32d22c9819196470ec875fca6c1cacd74e0"
 dependencies = [
  "bytes",
  "fuel-abi-types",
@@ -1731,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-signers"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee5a705cfb87a8fa51e28478597db38109701be82238534a4a18f34bc8e3d39"
+checksum = "51eff88f45d0b813a9f44200d7bb14678a04c04e4d42f8cdd7e7b4e130ae4664"
 dependencies = [
  "async-trait",
  "bytes",
@@ -1759,9 +1759,9 @@ dependencies = [
 
 [[package]]
 name = "fuels-test-helpers"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "944433f739289f94e5a415684251211cfdb511849b58e2350c524a9b0d60f1c5"
+checksum = "9b022b5daebc2c9e07bf35e6c7d71bc377859225c985fa900cca406b22a594eb"
 dependencies = [
  "fuel-core",
  "fuel-core-chain-config",
@@ -1788,13 +1788,14 @@ dependencies = [
 
 [[package]]
 name = "fuels-types"
-version = "0.36.1"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c90a74c9ef4703d87e0085240fb1ef53cf0266174482ba137e00dafd6515e4"
+checksum = "5b3328fa28eac1bd6925a50a9d925a448141d48a1c3cac812defbcee159087f4"
 dependencies = [
  "bech32 0.9.1",
  "chrono",
  "fuel-abi-types",
+ "fuel-asm 0.26.1",
  "fuel-core-chain-config",
  "fuel-core-client",
  "fuel-tx 0.26.1",
@@ -1810,7 +1811,6 @@ dependencies = [
  "strum 0.21.0",
  "strum_macros 0.21.1",
  "thiserror",
- "tokio",
 ]
 
 [[package]]

--- a/bridge-fungible-token/Cargo.toml
+++ b/bridge-fungible-token/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 
 [dependencies]
 fuel-core-interfaces = "0.15"
-fuels = { version = "0.36", features = ["fuel-core-lib"] }
+fuels = { version = "0.37", features = ["fuel-core-lib"] }
 primitive-types = "0.12.1"
 tokio = { version = "1.12", features = ["rt", "macros"] }
 

--- a/bridge-fungible-token/tests/harness.rs
+++ b/bridge-fungible-token/tests/harness.rs
@@ -44,7 +44,7 @@ mod success {
             message_inputs,
             test_contract_id,
             provider,
-        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None).await;
+        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None, None).await;
 
         // Relay the test message to the test contract
         let _receipts = env::relay_message_to_contract(
@@ -98,7 +98,7 @@ mod success {
             message_inputs,
             test_contract_id,
             provider,
-        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None).await;
+        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None, None).await;
 
         // Relay the test message to the test contract
         let _receipts = env::relay_message_to_contract(
@@ -154,7 +154,7 @@ mod success {
             message_inputs,
             test_contract_id,
             provider,
-        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None).await;
+        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None, None).await;
 
         // Relay the test message to the test contract
         let receipts = env::relay_message_to_contract(
@@ -258,7 +258,7 @@ mod success {
             message_inputs,
             test_contract_id,
             provider,
-        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None).await;
+        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None, None).await;
 
         // Relay the test message to the test contract
         let _receipts = env::relay_message_to_contract(
@@ -362,7 +362,7 @@ mod success {
             message_inputs,
             test_contract_id,
             provider,
-        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None).await;
+        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None, None).await;
 
         // Relay the test message to the test contract
         let _receipts = env::relay_message_to_contract(
@@ -466,7 +466,7 @@ mod success {
             message_inputs,
             test_contract_id,
             provider,
-        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None).await;
+        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None, None).await;
 
         // Relay the test message to the test contract
         let receipts = env::relay_message_to_contract(
@@ -532,7 +532,7 @@ mod success {
             message_inputs,
             test_contract_id,
             provider,
-        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None).await;
+        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None, None).await;
 
         // Relay the test message to the test contract
         let receipts = env::relay_message_to_contract(
@@ -601,7 +601,7 @@ mod success {
             message_inputs,
             test_contract_id,
             provider,
-        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None).await;
+        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None, None).await;
 
         // Relay the test message to the test contract
         let receipts = env::relay_message_to_contract(
@@ -670,7 +670,7 @@ mod success {
             message_inputs,
             test_contract_id,
             provider,
-        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None).await;
+        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None, None).await;
 
         // Relay the test message to the test contract
         let receipts = env::relay_message_to_contract(
@@ -821,7 +821,7 @@ mod revert {
             message_inputs,
             test_contract_id,
             provider,
-        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None).await;
+        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None, None).await;
 
         // Relay the test message to the test contract
         let _receipts = env::relay_message_to_contract(
@@ -895,7 +895,7 @@ mod revert {
             message_inputs,
             _test_contract_id,
             _provider,
-        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], Some(bad_sender)).await;
+        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], Some(bad_sender), None).await;
 
         // Relay the test message to the test contract
         let _receipts = env::relay_message_to_contract(
@@ -932,7 +932,7 @@ mod revert {
             message_inputs,
             test_contract_id,
             provider,
-        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None).await;
+        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None, None).await;
 
         // Relay the test message to the test contract
         let receipts = env::relay_message_to_contract(
@@ -1006,7 +1006,7 @@ mod revert {
             message_inputs,
             test_contract_id,
             provider,
-        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None).await;
+        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], None, None).await;
 
         // Relay the test message to the test contract
         let receipts = env::relay_message_to_contract(

--- a/bridge-fungible-token/tests/harness.rs
+++ b/bridge-fungible-token/tests/harness.rs
@@ -895,7 +895,14 @@ mod revert {
             message_inputs,
             _test_contract_id,
             _provider,
-        ) = env::setup_environment(&mut wallet, vec![coin], vec![message], Some(bad_sender), None).await;
+        ) = env::setup_environment(
+            &mut wallet,
+            vec![coin],
+            vec![message],
+            Some(bad_sender),
+            None,
+        )
+        .await;
 
         // Relay the test message to the test contract
         let _receipts = env::relay_message_to_contract(

--- a/bridge-fungible-token/tests/utils/builder.rs
+++ b/bridge-fungible-token/tests/utils/builder.rs
@@ -28,7 +28,7 @@ pub async fn build_contract_message_tx(
     optional_inputs: &[Input],
     optional_outputs: &[Output],
     params: TxParameters,
-) -> Script {
+) -> ScriptTransaction {
     // Get the script and predicate for contract messages
     let (script_bytecode, _) = get_contract_message_script().await;
 
@@ -68,8 +68,9 @@ pub async fn build_contract_message_tx(
     tx_inputs.append(&mut optional_inputs.to_vec());
     tx_outputs.append(&mut optional_outputs.to_vec());
 
-    // Create the transaction
-    Transaction::script(
+    // Create a new transaction
+    let mut script_tx = ScriptTransaction::new(tx_inputs, tx_outputs, params);
+    let tx = Transaction::script(
         params.gas_price,
         CONTRACT_MESSAGE_MIN_GAS * 10,
         params.maturity,
@@ -78,5 +79,6 @@ pub async fn build_contract_message_tx(
         tx_inputs,
         tx_outputs,
         vec![],
-    )
+    );
+    script_tx.with_script(tx)
 }

--- a/bridge-fungible-token/tests/utils/builder.rs
+++ b/bridge-fungible-token/tests/utils/builder.rs
@@ -78,6 +78,6 @@ pub async fn build_contract_message_tx(
         tx_inputs,
         tx_outputs,
         vec![],
-    ).into()
-
+    )
+    .into()
 }

--- a/bridge-fungible-token/tests/utils/builder.rs
+++ b/bridge-fungible-token/tests/utils/builder.rs
@@ -69,8 +69,7 @@ pub async fn build_contract_message_tx(
     tx_outputs.append(&mut optional_outputs.to_vec());
 
     // Create a new transaction
-    let mut script_tx = ScriptTransaction::new(tx_inputs, tx_outputs, params);
-    let tx = Transaction::script(
+    Transaction::script(
         params.gas_price,
         CONTRACT_MESSAGE_MIN_GAS * 10,
         params.maturity,
@@ -79,6 +78,6 @@ pub async fn build_contract_message_tx(
         tx_inputs,
         tx_outputs,
         vec![],
-    );
-    script_tx.with_script(tx)
+    ).into()
+
 }

--- a/bridge-fungible-token/tests/utils/environment.rs
+++ b/bridge-fungible-token/tests/utils/environment.rs
@@ -191,12 +191,12 @@ pub async fn setup_environment(
     wallet.set_provider(provider.clone());
 
     let test_contract_id = match configurables {
-        Some(c) => Contract::deploy_with_parameters(
+        Some(config) => Contract::deploy_with_parameters(
             TEST_BRIDGE_FUNGIBLE_TOKEN_CONTRACT_BINARY,
             &wallet,
             TxParameters::default(),
             StorageConfiguration::default(),
-            c.into(),
+            config.into(),
             Salt::default(),
         )
         .await

--- a/bridge-fungible-token/tests/utils/environment.rs
+++ b/bridge-fungible-token/tests/utils/environment.rs
@@ -130,6 +130,7 @@ pub async fn setup_environment(
     coins: Vec<(Word, AssetId)>,
     messages: Vec<(Word, Vec<u8>)>,
     sender: Option<&str>,
+    configurables: Option<BridgeFungibleTokenContractConfigurables>,
 ) -> (
     BridgeFungibleTokenContract,
     Input,
@@ -189,15 +190,27 @@ pub async fn setup_environment(
     // Add provider to wallet
     wallet.set_provider(provider.clone());
 
-    // Deploy the target contract used for testing processing messages
-    let test_contract_id = Contract::deploy(
-        TEST_BRIDGE_FUNGIBLE_TOKEN_CONTRACT_BINARY,
-        &wallet,
-        TxParameters::default(),
-        StorageConfiguration::default(),
-    )
-    .await
-    .unwrap();
+    let test_contract_id = match configurables {
+        Some(c) => Contract::deploy_with_parameters(
+            TEST_BRIDGE_FUNGIBLE_TOKEN_CONTRACT_BINARY,
+            &wallet,
+            TxParameters::default(),
+            StorageConfiguration::default(),
+            c.into(),
+            Salt::default(),
+        )
+        .await
+        .unwrap(),
+        None => Contract::deploy(
+            TEST_BRIDGE_FUNGIBLE_TOKEN_CONTRACT_BINARY,
+            &wallet,
+            TxParameters::default(),
+            StorageConfiguration::default(),
+        )
+        .await
+        .unwrap(),
+    };
+
     let test_contract = BridgeFungibleTokenContract::new(test_contract_id.clone(), wallet.clone());
 
     // Build inputs for provided coins
@@ -273,7 +286,7 @@ pub async fn relay_message_to_contract(
 }
 
 /// Relays a message-to-contract message
-pub async fn sign_and_call_tx(wallet: &WalletUnlocked, tx: &mut Script) -> Vec<Receipt> {
+pub async fn sign_and_call_tx(wallet: &WalletUnlocked, tx: &mut ScriptTransaction) -> Vec<Receipt> {
     // Get provider and client
     let provider = wallet.get_provider().unwrap();
 


### PR DESCRIPTION
This doesn't implement #49, but it does the initial setup tasks needed to implement it.
Part of this includes bumping the SDK to v0.37 to support configurables.
The next couple PRs will be refactoring and adding tests, so I want this to land first to avoid too many conflicts.